### PR TITLE
v2.0.2: Fix ArcaneLogger LoggerName mixin to be runtime safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@
   Mix `LoggerName` into a `LoggingInterface` subclass and override
   `name` to expose a runtime-accessible name inside `log()`.
 
+#### Migration Steps (LoggingFeature)
+
+1. Replace any `@LoggingFeature("...")` annotation with `with LoggerName` and
+   add an `@override String get name => '...';` getter to the class body.
+
+Before:
+
+```dart
+@LoggingFeature("my-feature")
+class MyLogger implements LoggingInterface {...}
+```
+
+After:
+
+```dart
+class MyLogger implements LoggingInterface with LoggerName {
+  @override
+  String get name => "my-feature";
+}
+```
+
 ## 2.0.1
 
 ### Arcane Framework

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+### Logging Service
+
+- [BREAKING] Replaced the `@LoggingFeature(...)` annotation (compile-time only,
+  not readable at runtime in Flutter) with the `LoggerName` mixin.
+  Mix `LoggerName` into a `LoggingInterface` subclass and override
+  `name` to expose a runtime-accessible name inside `log()`.
+
 ## 2.0.1
 
 ### Arcane Framework

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,13 @@ Before:
 
 ```dart
 @LoggingFeature("my-feature")
-class MyLogger implements LoggingInterface {...}
+class MyLogger extends LoggingInterface {...}
 ```
 
 After:
 
 ```dart
-class MyLogger implements LoggingInterface with LoggerName {
+class MyLogger extends LoggingInterface with LoggerName {
   @override
   String get name => "my-feature";
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 2.0.2
 
 ### Logging Service
 

--- a/README.md
+++ b/README.md
@@ -514,12 +514,13 @@ class ExternalLogger extends LoggingInterface with LoggingInitialization {
 }
 ```
 
-If you want to tag a destination, annotate the interface with
-`@LoggingFeature(...)`:
+If you want to give a destination a name and access it at runtime,
+mix in `LoggerName` and override `name`:
 
 ```dart
-@LoggingFeature("Analytics")
-class AnalyticsLogger extends LoggingInterface {
+class AnalyticsLogger extends LoggingInterface with LoggerName {
+  @override
+  String get name => 'Analytics';
 
   @override
   void log(
@@ -529,6 +530,7 @@ class AnalyticsLogger extends LoggingInterface {
     StackTrace? stackTrace,
     Object? extra,
   }) {
+    // name is accessible here at runtime.
     // Forward to analytics pipeline.
   }
 }
@@ -545,12 +547,14 @@ Arcane.logger.interceptors.add(
 );
 ```
 
-You can use this tag as source-level documentation and keep destination routing
+You can use `name` inside `log()` and keep destination routing
 explicit in interceptors.
 
 ```dart
-@LoggingFeature("auth")
-class AuthLogger extends LoggingInterface {
+class AuthLogger extends LoggingInterface with LoggerName {
+  @override
+  String get name => 'auth';
+
   @override
   void log(
     String message, {

--- a/lib/src/services/logging/logging_interface.dart
+++ b/lib/src/services/logging/logging_interface.dart
@@ -41,13 +41,24 @@ mixin LoggingInitialization implements LoggingInitializable {
   }
 }
 
-/// Annotation used to tag a logging destination with a feature name.
+/// Opt-in mixin that exposes a [name] string on a [LoggingInterface].
+///
+/// Mix this into a concrete logger to declare what [name] should be associated
+/// with this logging interface.
 ///
 /// Example:
-/// `@LoggingFeature("analytics")`
-final class LoggingFeature {
-  const LoggingFeature(this.value);
-
-  /// The feature name associated with this logging destination.
-  final String value;
+/// ```dart
+/// class MyLogger extends LoggingInterface with LoggerName {
+///   @override
+///   String get name => 'my-feature';
+///
+///   @override
+///   void log(String message, {...}) {
+///     print('[$name] $message');
+///   }
+/// }
+/// ```
+mixin LoggerName on LoggingInterface {
+  /// The name associated with this logging interface.
+  String get name;
 }

--- a/lib/src/services/logging/logging_service.dart
+++ b/lib/src/services/logging/logging_service.dart
@@ -470,8 +470,8 @@ class ArcaneLogger {
   void clearPersistentMetadata() => _additionalMetadata.clear();
 
   /// Resets the Arcane logging service by clearing all persistent metadata,
-  /// clearing all registered [LoggingInterface]s and marking the logging
-  /// service as no longer being initialized.
+  /// clearing all registered [LoggingInterface]s, clearing all interceptors,
+  /// and marking the logging service as no longer being initialized.
   void reset() {
     dispose();
     I._interfaceRegistrations.clear();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: arcane_framework
 description: "Agnostic Reusable Component Architecture for New Ecosystems: a
   modern framework for bootstrapping new applications"
-version: 2.0.1
+version: 2.0.2
 repository: https://github.com/hanskokx/arcane_framework
 issue_tracker: https://github.com/hanskokx/arcane_framework/issues
 

--- a/test/services/logging/logging_service_test.dart
+++ b/test/services/logging/logging_service_test.dart
@@ -110,9 +110,37 @@ class RedactingLogInterceptor implements LogInterceptor {
   }
 }
 
+class TestLoggerWithLoggerName extends LoggingInterface with LoggerName {
+  @override
+  String get name => "test-logger";
+
+  final List<LogEvent> events = [];
+
+  @override
+  void log(
+    String message, {
+    Map<String, Object?>? metadata,
+    Level? level,
+    StackTrace? stackTrace,
+    Object? extra,
+  }) {
+    events.add(
+      LogEvent(
+        message: message,
+        metadata: metadata == null ? null : Map<String, Object?>.from(metadata),
+        level: level,
+        stackTrace: stackTrace,
+        extra: extra,
+      ),
+    );
+  }
+}
+
 void main() {
   late TestLoggingInterface myInterface;
   late LogInterceptor prefixInterceptor;
+  final TestLoggerWithLoggerName loggerWithLoggerName =
+      TestLoggerWithLoggerName();
 
   setUp(() {
     Arcane.logger.reset();
@@ -676,5 +704,13 @@ void main() {
         expect(myInterface.events.single.message, logMessage);
       });
     });
+  });
+
+  test("LoggerName mixin exposes name at runtime", () {
+    expect(loggerWithLoggerName.name, "test-logger");
+
+    loggerWithLoggerName.log("Test message");
+    expect(loggerWithLoggerName.events.length, 1);
+    expect(loggerWithLoggerName.events.first.message, "Test message");
   });
 }


### PR DESCRIPTION
## Summary

Fixes a broken API introduced in 2.0.1: the `@LoggingFeature(...)` annotation was not readable at runtime in Flutter (Dart annotations require `dart:mirrors`, which is unavailable in Flutter), making the feature non-functional as documented.

## Changes

### Breaking

- **`@LoggingFeature(...)` annotation removed.** It was compile-time metadata only and could not be accessed inside a `log()` method body at runtime.

- **Replaced with the `LoggerName` mixin.** Mix `LoggerName` into any `LoggingInterface` subclass and override the `name` getter to expose a runtime-accessible name:

  ```dart
  class AnalyticsLogger extends LoggingInterface with LoggerName {
    @override
    String get name => 'analytics';

    @override
    void log(String message, { ... }) {
      print('[$name] $message'); // works at runtime
    }
  }
  ```

### Also included

- `ArcaneLogger.reset()` now clears registered interceptors in addition to metadata and interfaces. The behavior hasn't changed, but it has been documented more clearly in the dartdoc comments.

## Migration

Replace any `@LoggingFeature("...")` annotation with `with LoggerName` and add an `@override String get name => '...';` getter to the class body.