### PR TITLE
refactor(api): Remove export of Error and Ok from result_monad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 2.0.6
+
+### Arcane Framework
+
+- [BREAKING] This package no longer exports the `Error` and `Ok` symbols from
+  the `result_monad` package.
+
+#### Migration Steps (`Error`/`Ok`)
+
+1. Add the `result_monad` package to your `pubspec.yaml` file.
+2. Use the import `import 'package:result_monad/result_monad.dart';` to access
+   `Error` and `Ok` symbols.
+
 ## 2.0.5
 
 ### Arcane Framework

--- a/lib/arcane_framework.dart
+++ b/lib/arcane_framework.dart
@@ -52,4 +52,4 @@ export "package:arcane_framework/src/services/theme/arcane_theme.dart";
 export "package:arcane_framework/src/services/theme/theme_extensions.dart";
 export "package:arcane_framework/src/services/theme/theme_service.dart";
 export "package:arcane_framework/src/services/theme/theme_switcher.dart";
-export "package:result_monad/result_monad.dart";
+export "package:result_monad/result_monad.dart" hide Error, Ok;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: arcane_framework
 description: "Agnostic Reusable Component Architecture for New Ecosystems: a
   modern framework for bootstrapping new applications"
-version: 2.0.5
+version: 2.0.6
 repository: https://github.com/hanskokx/arcane_framework
 issue_tracker: https://github.com/hanskokx/arcane_framework/issues
 


### PR DESCRIPTION
The `Error` and `Ok` symbols from the `result_monad` package are no longer
re-exported directly by `arcane_framework`. Consumers needing these
symbols must now explicitly import them from `package:result_monad`.
This clarifies dependency ownership and reduces `arcane_framework`'s
public API surface.
